### PR TITLE
Line Padding Bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ docker tag chaquo:hpschd_vX.Y.Z docker.io/maroda/chaquo:hpschd_vX.Y.Z
 docker push docker.io/maroda/chaquo:hpschd_vX.Y.Z
 ```
 
+### Run Docker Locally
+
+```
+docker run --rm --name hpschd -p 9999:9999 maroda/chaquo:hpschd_v1.4.0
+```
+
 ### Running on AWS ECS Fargate
 
 Once the container has been updated in DockerHub, it can be launched/updated on AWS ECS Fargate.

--- a/cron.go
+++ b/cron.go
@@ -25,7 +25,7 @@ func fetchCron() {
 	apodnow := "https://api.nasa.gov/planetary/apod?api_key=Ijb0zLeEt71HMQdy8YjqB583FK3bdh1yThVJYzpu"
 	apodenv := "HPSCHD_NASA_APOD_URL" // Optional ENV VAR
 	url := envVar(apodenv, apodnow)   // NASA APOD URL to query, default if no ENV VAR
-	var afreq uint64 = 15             // Frequency (s) to check
+	var afreq uint64 = 10             // Frequency (s) to check
 
 	// Start a new fetch job immediately, followed every afreq seconds.
 	fcron := gocron.NewScheduler(time.UTC)

--- a/cron.go
+++ b/cron.go
@@ -25,7 +25,7 @@ func fetchCron() {
 	apodnow := "https://api.nasa.gov/planetary/apod?api_key=Ijb0zLeEt71HMQdy8YjqB583FK3bdh1yThVJYzpu"
 	apodenv := "HPSCHD_NASA_APOD_URL" // Optional ENV VAR
 	url := envVar(apodenv, apodnow)   // NASA APOD URL to query, default if no ENV VAR
-	var afreq uint64 = 900            // Frequency (s) to check
+	var afreq uint64 = 15             // Frequency (s) to check
 
 	// Start a new fetch job immediately, followed every afreq seconds.
 	fcron := gocron.NewScheduler(time.UTC)

--- a/dataops.go
+++ b/dataops.go
@@ -2,16 +2,16 @@
 
 	Mesostic Data Operations
 
-	Currently a lot of filesystem stuff,
-		intended to be expandable into a database.
-
-	Also configurations and external variable handling.
+	- Filesystem / database access
+	- Specialized random / hash values
+	- Configurations
 
 */
 
 package main
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -153,4 +153,13 @@ func nasaNewREAD() string {
 		log.Info().Str("fu", fu).Msg("No new filename presented, initiate chance operations.")
 		return "HPSCHD"
 	}
+}
+
+// SHA1 for consistent size keys
+func shakey(k string) string {
+	s := sha1.New()
+	s.Write([]byte(k))
+	bash := s.Sum(nil)
+	hash := fmt.Sprintf("%x", bash)
+	return hash
 }

--- a/mesostic.go
+++ b/mesostic.go
@@ -80,6 +80,9 @@ CharLoop:
 			// as long as the character isn't the current Spine Character fill in the WestSide fragment.
 			if char != z[*ict] {
 				wstack = append(wstack, char)
+			} else if char == string(s[len(s)-1]) {
+				fmt.Printf("\nlast character is: %s\n", char)
+				break
 			} else {
 				// SpineString hit!
 				char = strings.ToUpper(char)  // Spine Character is capitalized

--- a/mesostic.go
+++ b/mesostic.go
@@ -2,16 +2,11 @@
 
 	Mesostic Engine
 
-	BUG ::: Maybe??? Unsure what's going on here, but after left running for several days on ECS,
-		the whitespace padding disappeared. When the tasks/containers were restarted,
-		the whitespace padding returned. ¯\_(ツ)_/¯
-
 */
 
 package main
 
 import (
-	"crypto/sha1"
 	"fmt"
 	"io/ioutil"
 	"sort"
@@ -32,9 +27,6 @@ type LineFrag struct {
 type LineFrags []LineFrag
 
 /* These globals should be changed to... ???  */
-
-// this can be made into a return value
-var padCount int // global to track right-align padding
 
 // this will need to be passed as a pointer like the ictus/nexus stuff
 var fragCount int // global to count total fragment combinations (i.e. lines)
@@ -63,8 +55,9 @@ func Spine(z string) []string {
 //		c == line number
 //		ict == ictus of the SpineString characters
 //		nex == next ictus (not always ict + 1)
+//		spaces == Pointer ::: current left-aligned whitespace
 //
-func mesoLine(s string, z []string, c int, ict *int, nex *int) {
+func mesoLine(s string, z []string, c int, ict *int, nex *int, spaces *int) {
 	var wstack []string // slice for rebuilding the west fragment
 	var estack []string // slice for rebuilding the east fragment
 	var mode int
@@ -80,9 +73,6 @@ CharLoop:
 			// as long as the character isn't the current Spine Character fill in the WestSide fragment.
 			if char != z[*ict] {
 				wstack = append(wstack, char)
-			} else if char == string(s[len(s)-1]) {
-				fmt.Printf("\nlast character is: %s\n", char)
-				break
 			} else {
 				// SpineString hit!
 				char = strings.ToUpper(char)  // Spine Character is capitalized
@@ -122,14 +112,16 @@ CharLoop:
 	fragmentW := strings.Join(wstack, "")                // WestSide fragment
 	fragmentE := strings.Join(estack, "")                // EastSide fragment
 	fragkey := shakey(fragmentW + fmt.Sprint(fragCount)) // unique identifier and consistent key sizes
-	if len(fragmentW) > padCount {                       // record the longest WestSide fragment length
-		padCount = len(fragmentW)
-	}
 	fragCount++
 
 	// Add results to a new map entry
 	// Some or all of this might be better off as pointers...
 	fragMents[fragkey] = LineFrag{Index: c, LineNum: fragCount, WChars: len(fragmentW), Data: fragmentW + fragmentE}
+
+	// record the longest WestSide fragment length, but calculate it from the passed value
+	if len(fragmentW) > *spaces {
+		*spaces = len(fragmentW)
+	}
 }
 
 // Ictus ::: Enables the rotation of SpineString characters by operating on the index.
@@ -156,7 +148,7 @@ func Ictus(lss int, isp *int, nsp *int) {
 	}
 }
 
-// Sort ::: linefragments by LineNum
+// Sort Interface ::: linefragments by LineNum (lnc)
 func (ls LineFrags) Len() int {
 	return len(ls)
 }
@@ -165,15 +157,6 @@ func (ls LineFrags) Swap(i, j int) {
 }
 func (ls LineFrags) Less(i, j int) bool {
 	return ls[i].LineNum < ls[j].LineNum
-}
-
-// SHA1 for consistent size keys
-func shakey(k string) string {
-	s := sha1.New()
-	s.Write([]byte(k))
-	bash := s.Sum(nil)
-	hash := fmt.Sprintf("%x", bash)
-	return hash
 }
 
 // mesoMain ::: Takes a filename as input for processing.
@@ -189,6 +172,7 @@ func mesoMain(f string, z string, o chan<- string) {
 	var lnc int               // line counts for the Index
 	var ictus int             // SpineString character address
 	var nexus int = ictus + 1 // Next SpineString character address
+	var spaces int = 0        // Left-aligned whitespace for all lines
 
 	// split the SpineString into a slice of characters
 	spineChars := Spine(z)
@@ -206,7 +190,13 @@ func mesoMain(f string, z string, o chan<- string) {
 		lnc++
 
 		// mesoLine populates a global map, there is no return value
-		mesoLine(strings.ToLower(sline), spineChars, lnc, &ictus, &nexus)
+		mesoLine(strings.ToLower(sline), spineChars, lnc, &ictus, &nexus, &spaces)
+
+		log.Debug().
+			Int("lnc", lnc).
+			Int("ictus", ictus).
+			Int("spaces", spaces).
+			Msg("left-aligned whitespace")
 
 		// Once the mesostic line has been created and added to the data map,
 		// operate on the Ictus values to construct the next line
@@ -226,13 +216,14 @@ func mesoMain(f string, z string, o chan<- string) {
 	// Sort is configured on LineNum.
 	sort.Sort(linefragments)
 
-	// Uneven padding is accomplished by subtracting
-	//   the length of the current WestSide fragment
-	//   from the length of the longest WestSide fragment (padCount)
 	for i := 0; i < len(linefragments); i++ {
-		padMe := padCount - linefragments[i].WChars
-		spaces := strings.Repeat(" ", padMe)
-		fragstack = append(fragstack, spaces)
+		// define 'West Side' whitespace as
+		//  (length of the longest fragment) - (length of the current fragment)
+		padMe := spaces - linefragments[i].WChars
+		printspace := strings.Repeat(" ", padMe)
+
+		// format the new line with leading whitespace and trailing line return
+		fragstack = append(fragstack, printspace)
 		fragstack = append(fragstack, linefragments[i].Data)
 		fragstack = append(fragstack, "\n")
 	}


### PR DESCRIPTION
The functionality that pads the left-alignment with whitespace in order to line up the Mesostic is no longer a global variable and is passed as a pointer instead. The suspicion is that competing/subsequent/race-conditioned runs using a global variable was a collision condition, accumulating integers instead of having a stateful set of them, causing too much padding to be added.